### PR TITLE
Changes in Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ to get information about the corpus (the most frequent words)
 
 ```python corpus_info.py data/arz.wiki```
 
+# The above command is not going to work in python 2.7 becuase in case of Python 2.7 , it doesnot support 'maketrans' attribute ,present in the file (corpus_info.py) at line 8.
+
+# To work that command properly it should  be replaced by -
+
+  ''' python3 corpus_info.py data/arz.wiki '''
+  
+  # It works fine. (As 'maketrans' is supported in Python 3.x)
+
 
 ## Related projects
 This project is used to extract [Comparable Documents from Wikipedia](https://github.com/motazsaad/comparableWikiCoprus/)

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ to get information about the corpus (the most frequent words)
 
 ```python corpus_info.py data/arz.wiki```
 
-# The above command is not going to work in python 2.7 becuase in case of Python 2.7 , it doesnot support 'maketrans' attribute ,present in the file (corpus_info.py) at line 8.
+ The above command is not going to work in python 2.7 becuase in case of Python 2.7 , it doesnot support 'maketrans' attribute ,present in the file (corpus_info.py) at line 8.
 
-# To work that command properly it should  be replaced by -
+ To work that command properly it should  be replaced by -
 
   ''' python3 corpus_info.py data/arz.wiki '''
   
-  # It works fine. (As 'maketrans' is supported in Python 3.x)
+   It works fine. (As 'maketrans' is supported in Python 3.x)
 
 
 ## Related projects


### PR DESCRIPTION
The 'maketrans ' attribute doesnot work with Python 2.x but it works in Python 3.x
 So  the command should be used as -

''' python3 corpus_info.py data/arz.wiki '''

Instead of -

python corpus_info.py data/arz.wiki 